### PR TITLE
build: remove mise lock

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -1,8 +1,0 @@
-[[tools.hugo-extended]]
-version = "0.161.1"
-backend = "aqua:gohugoio/hugo/hugo-extended"
-"platforms.linux-arm64" = { checksum = "sha256:e05382fbe2b2b9e51dfd01fbb6cd439d84c83a1862ac92000b25fbf2c06f699c", url = "https://github.com/gohugoio/hugo/releases/download/v0.161.1/hugo_extended_0.161.1_linux-arm64.tar.gz"}
-"platforms.linux-x64" = { checksum = "sha256:9b82cf3211b2321f189a005dd157e6f4bd5c65f2bf5e9eefd2f5e0803c12103c", url = "https://github.com/gohugoio/hugo/releases/download/v0.161.1/hugo_extended_0.161.1_linux-amd64.tar.gz"}
-"platforms.macos-arm64" = { checksum = "sha256:ffa5333f0733b21a5c2501cf6fa8b6a99ef3f1953d047f5dc9b47f7cc35da768", url = "https://github.com/gohugoio/hugo/releases/download/v0.161.1/hugo_extended_0.161.1_darwin-universal.pkg"}
-"platforms.macos-x64" = { checksum = "sha256:ffa5333f0733b21a5c2501cf6fa8b6a99ef3f1953d047f5dc9b47f7cc35da768", url = "https://github.com/gohugoio/hugo/releases/download/v0.161.1/hugo_extended_0.161.1_darwin-universal.pkg"}
-"platforms.windows-x64" = { checksum = "sha256:5116d0d9e3974177658c2db131c80bf87bc68babdcc1cbc7362b2f164fdf32cd", url = "https://github.com/gohugoio/hugo/releases/download/v0.161.1/hugo_extended_0.161.1_windows-amd64.zip"}

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,3 @@
 [tools]
 # extended version of Hugo is required for SASS support
 hugo-extended = "0.161.1"
-
-[settings]
-lockfile = true


### PR DESCRIPTION
## Related GitHub Issues
<!-- Link to any related GitHub issues that this pull request addresses or closes. -->

## Problem
<!-- A clear description of the problem that this pull request is solving. -->

So Renovate Bot can update the dependencies. It failed recently because it doesn't run 'mise trust' after updating the mise.toml file.

## Solution
<!-- Describe the approach you took to solve the problem and the changes made in this pull request. -->

Remove lock file. 